### PR TITLE
Snapshot deployment & Gradle fixes

### DIFF
--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -3,12 +3,15 @@ name: 'SweetBlue Snapshot Deployment'
 on:
 
   workflow_dispatch:
+    inputs:
+      snapshot_version:
+        description: 'Additional version number to tack onto the snapshot version (eg 4.0.1 version, if you supply the snapshot version of 3, the version will end up as 4.0.1.3-SNAPSHOT'
+        required: false
+        default: ''
 
 jobs:
-  PreBuild:
+  TheTest:
     runs-on: ubuntu-latest
-    outputs:
-      snapshot_verified: ${{ steps.check_snapshot.outputs.is_snapshot }}
 
     steps:
       - uses: actions/checkout@v3
@@ -19,61 +22,48 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
-      - name: Write version file
-        run: ./gradlew writeVersionFile
-
-      - name: Verify Snapshot
-        id: check_snapshot
+      - name: Test out things
         run: |
-          number=(cat version.txt | grep -c "\-SNAPSHOT")
-          if [ "$number" ge 1 ]
-          then
-            echo true >> "$GITHUB_OUTPUT"
-          else
-            echo false >> "$GITHUB_OUTPUT"
-          fi
-
-  Build:
-    runs-on: ubuntu-latest
-    # Using the release environment for this step will force a manual approval in github
-    # before it can proceed
-    environment:
-      name: Snapshot
-
-    needs: PreBuild
-    if: needs.PreBuild.outputs.snapshot_verified
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Java 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Build Library And Sample Apps
-        run: ./gradlew assembleRelease
-
-  Deploy:
-    runs-on: ubuntu-latest
-    # Using the release environment for this step will force a manual approval in github
-    # before it can proceed
-    environment:
-      name: Snapshot
-
-    needs: Build
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Java 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
-      - name: Deploy to Azure
-        env:
-          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
-        run: ./gradlew assembleRelease sbjavadocJar publish
+          ./gradlew writeVersionFile
+          cat version.txt
+#  Build:
+#    runs-on: ubuntu-latest
+#    # Using the release environment for this step will force a manual approval in github
+#    # before it can proceed
+#    environment:
+#      name: Snapshot
+#
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Install Java 17
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'zulu'
+#          java-version: '17'
+#
+#      - name: Build Library And Sample Apps
+#        run: ./gradlew assembleRelease -PuseSnapshot=${{ github.event.inputs.snapshot_version }}
+#
+#  Deploy:
+#    runs-on: ubuntu-latest
+#    # Using the release environment for this step will force a manual approval in github
+#    # before it can proceed
+#    environment:
+#      name: Snapshot
+#
+#    needs: Build
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Install Java 17
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'zulu'
+#          java-version: '17'
+#
+#      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
+#      - name: Deploy to Azure
+#        env:
+#          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
+#        run: ./gradlew assembleRelease sbjavadocJar publish

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -6,24 +6,11 @@ on:
     inputs:
       snapshot_version:
         name: Snapshot Version
-        description: 'Additional version number to tack onto the snapshot version (eg 4.0.1 version, if you supply the snapshot version of 3, the version will end up as 4.0.1.3-SNAPSHOT'
+        description: 'Version number to concat to the snapshot version (eg 4.0.1 version, if you supply the snapshot version of 3, the version will end up as 4.0.1.3-SNAPSHOT'
         required: false
         default: ''
 
 jobs:
-  PreBuild:
-    runs-on: ubuntu-latest
-
-    outputs:
-      snapshot_version: ${{ steps.process_version.outputs.snapshot_version }}
-
-    steps:
-      - name: Process snapshot version parameter
-        id: process_version
-        env:
-          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && format('.{0}-SNAPSHOT', github.event.inputs.snapshot_version) || '' }}
-        run: echo "snapshot_version=$SNAPSHOT" >> "$GITHUB_OUTPUT"
-
   Deploy:
     runs-on: ubuntu-latest
     # Using the release environment for this step will force a manual approval in github
@@ -31,7 +18,6 @@ jobs:
     environment:
       name: Snapshot
 
-    needs: PreBuild
     steps:
       - uses: actions/checkout@v3
 
@@ -45,5 +31,5 @@ jobs:
       - name: Deploy to Azure
         env:
           AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
-          SNAPSHOT_VERSION: ${{ needs.PreBuild.outputs.snapshot_version }}
+          SNAPSHOT_VERSION: ${{ github.event.inputs.snapshot_version != '' && format('.{0}-SNAPSHOT', github.event.inputs.snapshot_version) || '' }}
         run: ./gradlew assembleRelease sbjavadocJar publish -PuseSnapshot="$SNAPSHOT_VERSION"

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Test out things
         env:
           VERSION: ${{ github.event.inputs.snapshot_version }}
-          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && ".$github.event.inputs.snapshot_version-SNAPSHOT" || "" }}
+          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && '.' + github.event.inputs.snapshot_version + '-SNAPSHOT' || '' }}
         run: |
           ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT"
           cat version.txt

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -11,12 +11,21 @@ on:
         default: ''
 
 jobs:
-  Build:
+  PreBuild:
     runs-on: ubuntu-latest
-    # Using the release environment for this step will force a manual approval in github
-    # before it can proceed
-    environment:
-      name: Snapshot
+
+    outputs:
+      snapshot_version: ${{ steps.process_version.snapshot_version }}
+
+    steps:
+      - name: Process snapshot version parameter
+        id: process_version
+        env:
+          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && format('.{0}-SNAPSHOT', github.event.inputs.snapshot_version) || '' }}
+        run: echo snapshot_version=$SNAPSHOT >> $GITHUB_OUTPUT
+
+  TheTest:
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -29,28 +38,53 @@ jobs:
 
       - name: Build Library And Sample Apps
         env:
-          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && format('.{0}-SNAPSHOT', github.event.inputs.snapshot_version) || '' }}
-        run: ./gradlew assembleRelease -PuseSnapshot="$SNAPSHOT"
+          SNAPSHOT_VERSION: ${{ needs.PreBuild.outputs.snapshot_version }}
+        run: |
+          ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT_VERSION"
+          cat version.txt
 
-  Deploy:
-    runs-on: ubuntu-latest
-    # Using the release environment for this step will force a manual approval in github
-    # before it can proceed
-    environment:
-      name: Snapshot
-
-    needs: Build
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Java 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
-      - name: Deploy to Azure
-        env:
-          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
-        run: ./gradlew assembleRelease sbjavadocJar publish
+#  Build:
+#    runs-on: ubuntu-latest
+#    # Using the release environment for this step will force a manual approval in github
+#    # before it can proceed
+#    environment:
+#      name: Snapshot
+#
+#    needs: PreBuild
+#
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Install Java 17
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'zulu'
+#          java-version: '17'
+#
+#      - name: Build Library And Sample Apps
+#        env:
+#          SNAPSHOT_VERSION: ${{ needs.PreBuild.outputs.snapshot_version }}
+#        run: ./gradlew assembleRelease -PuseSnapshot="$SNAPSHOT_VERSION"
+#
+#  Deploy:
+#    runs-on: ubuntu-latest
+#    # Using the release environment for this step will force a manual approval in github
+#    # before it can proceed
+#    environment:
+#      name: Snapshot
+#
+#    needs: Build
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Install Java 17
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'zulu'
+#          java-version: '17'
+#
+#      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
+#      - name: Deploy to Azure
+#        env:
+#          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
+#        run: ./gradlew assembleRelease sbjavadocJar publish

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Test out things
         run: |
-          ./gradlew writeVersionFile -PuseSnapshot=${{ github.events.inputs.snapshot_version }}
+          ./gradlew writeVersionFile -PuseSnapshot=${{ github.event.inputs.snapshot_version }}
           cat version.txt
 #  Build:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -27,46 +27,47 @@ jobs:
         run: |
           ./gradlew writeVersionFile -PuseSnapshot=".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"
           cat version.txt
-  Build:
-    runs-on: ubuntu-latest
-    # Using the release environment for this step will force a manual approval in github
-    # before it can proceed
-    environment:
-      name: Snapshot
 
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Java 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Build Library And Sample Apps
-        env:
-          SNAPSHOT: fromJSON('["", ".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"]')[${{ github.event.inputs.snapshot_version }} != ""]
-        run: ./gradlew assembleRelease -PuseSnapshot=$SNAPSHOT
-
-  Deploy:
-    runs-on: ubuntu-latest
-    # Using the release environment for this step will force a manual approval in github
-    # before it can proceed
-    environment:
-      name: Snapshot
-
-    needs: Build
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Java 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
-      - name: Deploy to Azure
-        env:
-          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
-        run: ./gradlew assembleRelease sbjavadocJar publish
+#  Build:
+#    runs-on: ubuntu-latest
+#    # Using the release environment for this step will force a manual approval in github
+#    # before it can proceed
+#    environment:
+#      name: Snapshot
+#
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Install Java 17
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'zulu'
+#          java-version: '17'
+#
+#      - name: Build Library And Sample Apps
+#        env:
+#          SNAPSHOT: fromJSON('["", ".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"]')[${{ github.event.inputs.snapshot_version }} != ""]
+#        run: ./gradlew assembleRelease -PuseSnapshot=$SNAPSHOT
+#
+#  Deploy:
+#    runs-on: ubuntu-latest
+#    # Using the release environment for this step will force a manual approval in github
+#    # before it can proceed
+#    environment:
+#      name: Snapshot
+#
+#    needs: Build
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Install Java 17
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'zulu'
+#          java-version: '17'
+#
+#      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
+#      - name: Deploy to Azure
+#        env:
+#          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
+#        run: ./gradlew assembleRelease sbjavadocJar publish

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -22,9 +22,10 @@ jobs:
       - name: Write version file
         run: ./gradlew writeVersionFile
 
-      - id: check_snapshot
+      - name: Verify Snapshot
+        id: check_snapshot
         run: |
-          number=cat version.txt | grep -c "\-SNAPSHOT"
+          number=(cat version.txt | grep -c "\-SNAPSHOT")
           if [ "$number" ge 1 ]
           then
             echo true >> "$GITHUB_OUTPUT"

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -24,11 +24,14 @@ jobs:
           SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && format('.{0}-SNAPSHOT', github.event.inputs.snapshot_version) || '' }}
         run: echo "snapshot_version=$SNAPSHOT" >> "$GITHUB_OUTPUT"
 
-  TheTest:
+  Deploy:
     runs-on: ubuntu-latest
+    # Using the release environment for this step will force a manual approval in github
+    # before it can proceed
+    environment:
+      name: Snapshot
 
     needs: PreBuild
-
     steps:
       - uses: actions/checkout@v3
 
@@ -38,55 +41,9 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
-      - name: Build Library And Sample Apps
+      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
+      - name: Deploy to Azure
         env:
+          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
           SNAPSHOT_VERSION: ${{ needs.PreBuild.outputs.snapshot_version }}
-        run: |
-          ./gradlew --no-daemon writeVersionFile -PuseSnapshot="$SNAPSHOT_VERSION"
-          cat version.txt
-
-#  Build:
-#    runs-on: ubuntu-latest
-#    # Using the release environment for this step will force a manual approval in github
-#    # before it can proceed
-#    environment:
-#      name: Snapshot
-#
-#    needs: PreBuild
-#
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Install Java 17
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'zulu'
-#          java-version: '17'
-#
-#      - name: Build Library And Sample Apps
-#        env:
-#          SNAPSHOT_VERSION: ${{ needs.PreBuild.outputs.snapshot_version }}
-#        run: ./gradlew assembleRelease -PuseSnapshot="$SNAPSHOT_VERSION"
-#
-#  Deploy:
-#    runs-on: ubuntu-latest
-#    # Using the release environment for this step will force a manual approval in github
-#    # before it can proceed
-#    environment:
-#      name: Snapshot
-#
-#    needs: Build
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Install Java 17
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'zulu'
-#          java-version: '17'
-#
-#      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
-#      - name: Deploy to Azure
-#        env:
-#          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
-#        run: ./gradlew assembleRelease sbjavadocJar publish
+        run: ./gradlew assembleRelease sbjavadocJar publish -PuseSnapshot="$SNAPSHOT_VERSION"

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -5,12 +5,35 @@ on:
   workflow_dispatch:
 
 jobs:
+  PreBuild:
+    runs-on: ubuntu-latest
+    outputs:
+      snapshot_verified: ${{ steps.check_snapshot.outputs.is_snapshot }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Write version file
+        run: ./gradlew writeVersionFile
+
+      - id: check_snapshot
+        run: cat version.txt | grep -c "\-SNAPSHOT" >> "$GITHUB_OUTPUT"
+
   Build:
     runs-on: ubuntu-latest
     # Using the release environment for this step will force a manual approval in github
     # before it can proceed
     environment:
       name: Snapshot
+
+    needs: PreBuild
+    if: needs.PreBuild.outputs.snapshot_verified
 
     steps:
       - uses: actions/checkout@v3
@@ -46,10 +69,3 @@ jobs:
         env:
           AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
         run: ./gradlew assembleRelease sbjavadocJar publish
-
-      - name: Deploy markdown to wiki
-        uses: SwiftDocOrg/github-wiki-publish-action@v1
-        with:
-          path: "markdown"
-        env:
-          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      snapshot_version: ${{ steps.process_version.snapshot_version }}
+      snapshot_version: ${{ steps.process_version.outputs.snapshot_version }}
 
     steps:
       - name: Process snapshot version parameter

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -27,44 +27,46 @@ jobs:
         run: |
           ./gradlew writeVersionFile -PuseSnapshot=".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"
           cat version.txt
-#  Build:
-#    runs-on: ubuntu-latest
-#    # Using the release environment for this step will force a manual approval in github
-#    # before it can proceed
-#    environment:
-#      name: Snapshot
-#
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Install Java 17
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'zulu'
-#          java-version: '17'
-#
-#      - name: Build Library And Sample Apps
-#        run: ./gradlew assembleRelease -PuseSnapshot=${{ github.event.inputs.snapshot_version }}
-#
-#  Deploy:
-#    runs-on: ubuntu-latest
-#    # Using the release environment for this step will force a manual approval in github
-#    # before it can proceed
-#    environment:
-#      name: Snapshot
-#
-#    needs: Build
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Install Java 17
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'zulu'
-#          java-version: '17'
-#
-#      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
-#      - name: Deploy to Azure
-#        env:
-#          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
-#        run: ./gradlew assembleRelease sbjavadocJar publish
+  Build:
+    runs-on: ubuntu-latest
+    # Using the release environment for this step will force a manual approval in github
+    # before it can proceed
+    environment:
+      name: Snapshot
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Build Library And Sample Apps
+        env:
+          SNAPSHOT: fromJSON('["", ".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"]')[${{ github.event.inputs.snapshot_version }} != ""]
+        run: ./gradlew assembleRelease -PuseSnapshot=$SNAPSHOT
+
+  Deploy:
+    runs-on: ubuntu-latest
+    # Using the release environment for this step will force a manual approval in github
+    # before it can proceed
+    environment:
+      name: Snapshot
+
+    needs: Build
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
+      - name: Deploy to Azure
+        env:
+          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
+        run: ./gradlew assembleRelease sbjavadocJar publish

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -22,7 +22,7 @@ jobs:
         id: process_version
         env:
           SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && format('.{0}-SNAPSHOT', github.event.inputs.snapshot_version) || '' }}
-        run: echo "snapshot_version=$SNAPSHOT" >> $GITHUB_OUTPUT
+        run: echo "snapshot_version=$SNAPSHOT" >> "$GITHUB_OUTPUT"
 
   TheTest:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -22,7 +22,7 @@ jobs:
         id: process_version
         env:
           SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && format('.{0}-SNAPSHOT', github.event.inputs.snapshot_version) || '' }}
-        run: echo snapshot_version=$SNAPSHOT >> $GITHUB_OUTPUT
+        run: echo "snapshot_version=$SNAPSHOT" >> $GITHUB_OUTPUT
 
   TheTest:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Test out things
         env:
           VERSION: ${{ github.event.inputs.snapshot_version }}
-          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && '.' + github.event.inputs.snapshot_version + '-SNAPSHOT' || '' }}
+          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && '.$github.event.inputs.snapshot_version + '-SNAPSHOT' || '' }}
         run: |
           ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT"
           cat version.txt

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       snapshot_version:
+        name: Snapshot Version
         description: 'Additional version number to tack onto the snapshot version (eg 4.0.1 version, if you supply the snapshot version of 3, the version will end up as 4.0.1.3-SNAPSHOT'
         required: false
         default: ''

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Test out things
         env:
           VERSION: ${{ github.event.inputs.snapshot_version }}
-          SNAPSHOT: fromJSON('["", ".$VERSION"]')[$VERSION != '']
+          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && ".$github.event.inputs.snapshot_version-SNAPSHOT" || "" }}
         run: |
           ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT"
           cat version.txt

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -11,8 +11,12 @@ on:
         default: ''
 
 jobs:
-  TheTest:
+  Build:
     runs-on: ubuntu-latest
+    # Using the release environment for this step will force a manual approval in github
+    # before it can proceed
+    environment:
+      name: Snapshot
 
     steps:
       - uses: actions/checkout@v3
@@ -23,54 +27,30 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
-      - name: Test out things
+      - name: Build Library And Sample Apps
         env:
-          VERSION: ${{ github.event.inputs.snapshot_version }}
           SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && format('.{0}-SNAPSHOT', github.event.inputs.snapshot_version) || '' }}
-        run: |
-          ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT"
-          cat version.txt
+        run: ./gradlew assembleRelease -PuseSnapshot="$SNAPSHOT"
 
-#  Build:
-#    runs-on: ubuntu-latest
-#    # Using the release environment for this step will force a manual approval in github
-#    # before it can proceed
-#    environment:
-#      name: Snapshot
-#
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Install Java 17
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'zulu'
-#          java-version: '17'
-#
-#      - name: Build Library And Sample Apps
-#        env:
-#          SNAPSHOT: fromJSON('["", ".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"]')[${{ github.event.inputs.snapshot_version }} != ""]
-#        run: ./gradlew assembleRelease -PuseSnapshot=$SNAPSHOT
-#
-#  Deploy:
-#    runs-on: ubuntu-latest
-#    # Using the release environment for this step will force a manual approval in github
-#    # before it can proceed
-#    environment:
-#      name: Snapshot
-#
-#    needs: Build
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Install Java 17
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'zulu'
-#          java-version: '17'
-#
-#      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
-#      - name: Deploy to Azure
-#        env:
-#          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
-#        run: ./gradlew assembleRelease sbjavadocJar publish
+  Deploy:
+    runs-on: ubuntu-latest
+    # Using the release environment for this step will force a manual approval in github
+    # before it can proceed
+    environment:
+      name: Snapshot
+
+    needs: Build
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      # Now build the artifacts, and javadocs jars, and publish to Azure Artifacts
+      - name: Deploy to Azure
+        env:
+          AZURE_ARTIFACTS_ENV_ACCESS_TOKEN: ${{ secrets.AZURE_ARTIFACTS_ENV_ACCESS_TOKEN }}
+        run: ./gradlew assembleRelease sbjavadocJar publish

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -25,9 +25,9 @@ jobs:
 
       - name: Test out things
         env:
-          SNAPSHOT: fromJSON('["", ".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"]')[${{ github.event.inputs.snapshot_version }} != ""]
+          SNAPSHOT: fromJSON('["", ".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"]')[${{ github.event.inputs.snapshot_version }} != '']
         run: |
-          ./gradlew writeVersionFile -PuseSnapshot=$SNAPSHOT
+          ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT"
           cat version.txt
 
 #  Build:

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Test out things
         env:
-          SNAPSHOT: fromJSON('["", ".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"]')[${{ github.event.inputs.snapshot_version }} != '']
+          SNAPSHOT: ${{ fromJSON('["", ".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"]')[${{ github.event.inputs.snapshot_version }} != ''] }}
         run: |
           ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT"
           cat version.txt

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -23,7 +23,14 @@ jobs:
         run: ./gradlew writeVersionFile
 
       - id: check_snapshot
-        run: cat version.txt | grep -c "\-SNAPSHOT" >> "$GITHUB_OUTPUT"
+        run: |
+          number=cat version.txt | grep -c "\-SNAPSHOT"
+          if [ "$number" ge 1 ]
+          then
+            echo true >> "$GITHUB_OUTPUT"
+          else
+            echo false >> "$GITHUB_OUTPUT"
+          fi
 
   Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -27,6 +27,8 @@ jobs:
   TheTest:
     runs-on: ubuntu-latest
 
+    needs: PreBuild
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Test out things
         env:
           VERSION: ${{ github.event.inputs.snapshot_version }}
-          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && '.$github.event.inputs.snapshot_version-SNAPSHOT' || '' }}
+          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && format('.{0}-SNAPSHOT', github.event.inputs.snapshot_version) || '' }}
         run: |
           ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT"
           cat version.txt

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Test out things
         env:
-          SNAPSHOT: ${{ fromJSON('["", ".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"]')[${{ github.event.inputs.snapshot_version }} != ''] }}
+          VERSION: ${{ github.event.inputs.snapshot_version }}
+          SNAPSHOT: fromJSON('["", ".$VERSION"]')[$VERSION != '']
         run: |
           ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT"
           cat version.txt

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Test out things
         env:
           VERSION: ${{ github.event.inputs.snapshot_version }}
-          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && '.$github.event.inputs.snapshot_version + '-SNAPSHOT' || '' }}
+          SNAPSHOT: ${{ github.event.inputs.snapshot_version != '' && '.$github.event.inputs.snapshot_version-SNAPSHOT' || '' }}
         run: |
           ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT"
           cat version.txt

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Test out things
         run: |
-          ./gradlew writeVersionFile -PuseSnapshot=${{ github.event.inputs.snapshot_version }}
+          ./gradlew writeVersionFile -PuseSnapshot=".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"
           cat version.txt
 #  Build:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           SNAPSHOT_VERSION: ${{ needs.PreBuild.outputs.snapshot_version }}
         run: |
-          ./gradlew writeVersionFile -PuseSnapshot="$SNAPSHOT_VERSION"
+          ./gradlew --no-daemon writeVersionFile -PuseSnapshot="$SNAPSHOT_VERSION"
           cat version.txt
 
 #  Build:

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Test out things
         run: |
-          ./gradlew writeVersionFile
+          ./gradlew writeVersionFile -PuseSnapshot=${{ github.events.inputs.snapshot_version }}
           cat version.txt
 #  Build:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -24,8 +24,10 @@ jobs:
           java-version: '17'
 
       - name: Test out things
+        env:
+          SNAPSHOT: fromJSON('["", ".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"]')[${{ github.event.inputs.snapshot_version }} != ""]
         run: |
-          ./gradlew writeVersionFile -PuseSnapshot=".${{ github.event.inputs.snapshot_version }}-SNAPSHOT"
+          ./gradlew writeVersionFile -PuseSnapshot=$SNAPSHOT
           cat version.txt
 
 #  Build:

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
 
 allprojects {
-    ext.appVersionName = "4.0.1"
+    ext.appVersionName = "4.0.1.2-SNAPSHOT"
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,15 @@ import java.util.regex.Pattern
 //  Standard top-level stuff (plugins/deps)  //
 // ========================================= //
 buildscript {
+    ext {
+        agp_version = '8.1.4'
+    }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.4'
+        classpath "com.android.tools.build:gradle:$agp_version"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,16 @@ buildscript {
 
 
 allprojects {
-    ext.appVersionName = "4.0.1.2-SNAPSHOT"
+    ext.appVersionName = "4.0.1"
+    if (project.hasProperty("useSnapshot")) {
+        def supplied = project.property("useSnapshot")
+        if (supplied.toString().trim().length() > 0) {
+            ext.appVersionName += supplied
+        } else {
+            ext.appVersionName += '-SNAPSHOT'
+        }
+    }
+
     repositories {
         google()
         mavenCentral()
@@ -105,7 +114,7 @@ task bumpVersionName() {
     group = "sweetblue"
     description = "Bumps up the release version of the current version, set in ext.appVersionName"
     doLast {
-        // This will find a string of the form a.b.c.d..... where there can be any number of version extensions following the first number
+        // This will find a string of the form 1.2.3.4..... where there can be any number of version extensions following the first number
         String regex = "([0-9]+(\\.[0-9]+)*)"
         String version = appVersionName
         Pattern pattern = Pattern.compile(regex)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 01 12:48:35 EDT 2020
+#Wed Nov 29 11:29:16 EST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
-
 version = ext.appVersionName
 
 android {
@@ -49,7 +48,7 @@ android {
     }
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     testLogging {
         exceptionFormat "full"
         events "skipped", "passed", "failed"
@@ -82,28 +81,38 @@ dependencies {
 //      Task/Method Definitions         //
 //////////////////////////////////////////
 
+afterEvaluate {
+    // Need to pull the boot classpath from project.android, and it needs to be in afterEvaluate
+    // So, update the gendocs task classpath with the value here
+    tasks.gendocs.classpath += files(project.android.getBootClasspath())
+}
+
 // Generate javadocs
-task gendocs(type: Javadoc) {
+tasks.register('gendocs', Javadoc) {
     failOnError false
     String path = project.projectDir.absolutePath + "/../scripts/assets/v3_style.css"
     options.stylesheetFile = new File(path)
     options.windowTitle = "SweetBlue"
     options.memberLevel = JavadocMemberLevel.PROTECTED
     options.author = true
-    options.links('http://d.android.com/reference')
+    options.links('https://developer.android.com/reference')
     exclude '**/BuildConfig.java'
     exclude '**/R.java'
     String v = "${SEMVER}"
     version = v.replace("_", '.')
     options.setDocTitle("SweetBlue " + version + " API")
     destinationDir = file("${rootDir.absolutePath}/javadocs/sweetblue/api")
-    source = android.sourceSets.main.java.srcDirs
-    classpath += files(android.getBootClasspath().join(File.pathSeparator))
+    source = android.sourceSets.main.java.sourceFiles
+    // This no longer works as of around version 7 or so of the android gradle plugin. The boot
+    // classpath isn't set until afterEvaluate. So, it gets set in the afterEvaluate block above
+    // this task definition instead
+//    classpath += files(project.android.getBootClasspath().join(File.pathSeparator))
     group = "sweetblue"
 }
 
 // Create javadoc jar file
-task sbjavadocJar(type: Jar, dependsOn: gendocs) {
+tasks.register('sbjavadocJar', Jar) {
+    dependsOn gendocs
     archiveFileName = getJavadocJarName("sweetblue")
     archiveClassifier.set("javadoc")
     from gendocs.destinationDir
@@ -112,18 +121,18 @@ task sbjavadocJar(type: Jar, dependsOn: gendocs) {
     description = "Generates the javadoc jar."
 }
 
-task sourcesJar(type: Jar) {
+tasks.register('sourcesJar', Jar) {
     archiveClassifier.set("sources")
     from android.sourceSets.main.java.srcDirs
 }
 
-task setVersionVar() {
+tasks.register('setVersionVar') {
     doLast {
         System.property("SWEETBLUE_VERSION", version)
     }
 }
 
-task bumpMarkdown() {
+tasks.register('bumpMarkdown') {
     group = "sweetblue"
     description = "Updates the markdown files and README.md with the latest version number."
     doLast {
@@ -162,7 +171,7 @@ def updateMarkdownFilesAndReadme() {
     }
 }
 
-task cleanFolders {
+tasks.register('cleanFolders') {
     doLast {
         delete "build"
     }

--- a/library/src/main/java/com/idevicesinc/sweetblue/internal/BleNodeImpl.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/internal/BleNodeImpl.java
@@ -326,7 +326,7 @@ abstract class BleNodeImpl implements IBleNode, UsesCustomNull
     }
 
     /**
-     * Safer version of {@link #cast()} that will return {@link BleDevice#NULL} or {@link BleServer#NULL}
+     * Safer version of {@link BleNodeImpl#cast()} that will return {@link BleDevice#NULL} or {@link BleServer#NULL}
      * if the cast cannot be made.
      */
     public @Nullable(Nullable.Prevalence.NEVER) <T extends BleNodeImpl> T cast(final Class<T> type)

--- a/library/src/main/java/com/idevicesinc/sweetblue/utils/Utils.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/utils/Utils.java
@@ -96,7 +96,6 @@ public class Utils
 		return isAndroidVersion(Build.VERSION_CODES.UPSIDE_DOWN_CAKE);
 	}
 
-	@androidx.annotation.ChecksSdkIntAtLeast(parameter = 0)
 	private static boolean isAndroidVersion(int apiVersion)
     {
         return Build.VERSION.SDK_INT >= apiVersion;

--- a/rx/build.gradle
+++ b/rx/build.gradle
@@ -42,7 +42,7 @@ android {
     namespace 'com.idevicesinc.sweetblue.rx'
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     testLogging {
         exceptionFormat "full"
         events "skipped", "passed", "failed"
@@ -63,30 +63,36 @@ dependencies {
     javadocDeps 'io.reactivex.rxjava2:rxjava:2.2.21'
 }
 
+afterEvaluate {
+    // Need to pull the boot classpath from project.android, and it needs to be in afterEvaluate
+    // So, update the gendocs task classpath with the value here
+    tasks.gendocs.classpath += files(project.android.getBootClasspath())
+    tasks.gendocs.classpath += project(':library').tasks.sourcesJar.outputs.getFiles()
+    tasks.gendocs.classpath += configurations.javadocDeps
+}
+
 // Generate javadocs
-task gendocs(type: Javadoc) {
+tasks.register('gendocs', Javadoc) {
     failOnError false
     String path = rootProject.projectDir.absolutePath + "/scripts/assets/v3_style.css"
     options.stylesheetFile = new File(path)
     options.windowTitle = "SweetBlueRx"
     options.memberLevel = JavadocMemberLevel.PROTECTED
     options.author = true
-    options.links('http://d.android.com/reference')
+    options.links('https://developer.android.com/reference')
     exclude '**/BuildConfig.java'
     exclude '**/R.java'
     String v = "${SEMVER}"
     version = v.replace("_", '.')
     options.setDocTitle("SweetBlueRx " + version + " API")
     destinationDir = file("${rootDir.absolutePath}/javadocs/sweetbluerx/api")
-    source = android.sourceSets.main.java.srcDirs
-    classpath += files(rootProject.projectDir.absolutePath + "/library/build/intermediates/aar_main_jar/release/classes.jar")
-    classpath += files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += configurations.javadocDeps
+    source = android.sourceSets.main.java.sourceFiles
     group = "sweetbluerx"
 }
 
 // Create javadoc jar file
-task sbjavadocJar(type: Jar, dependsOn: gendocs) {
+tasks.register('sbjavadocJar', Jar) {
+    dependsOn gendocs
     from gendocs.destinationDir
     archiveClassifier.set("javadoc")
     archiveFileName = getJavadocJarName("rx")

--- a/sweetunit/build.gradle
+++ b/sweetunit/build.gradle
@@ -1,3 +1,6 @@
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
@@ -53,30 +56,47 @@ dependencies {
     javadocDeps 'androidx.test.uiautomator:uiautomator:2.2.0'
 }
 
+afterEvaluate {
+    // Need to pull the boot classpath from project.android, and it needs to be in afterEvaluate
+    // So, update the gendocs task classpath with the value here
+    tasks.gendocs.classpath += files(project.android.getBootClasspath())
+    tasks.gendocs.classpath += project(':library').tasks.sourcesJar.outputs.getFiles()
+    def tmpDir = new File(project.buildDir, "tmpAar")
+    if (tmpDir.exists()) tmpDir.delete()
+    tmpDir.mkdirs()
+    configurations.javadocDeps.forEach {
+        if (it.name.endsWith(".aar")) {
+            extractClassesJar(it, tmpDir)
+        } else {
+            tasks.gendocs.classpath += fileTree(it)
+        }
+    }
+    tasks.gendocs.classpath += fileTree(tmpDir)
+    tasks.gendocs.classpath += files(configurations.javadocDeps)
+}
+
 // Generate javadocs
-task gendocs(type: Javadoc) {
+tasks.register('gendocs', Javadoc) {
     failOnError false
     String path = rootProject.projectDir.absolutePath + "/scripts/assets/v3_style.css"
     options.stylesheetFile = new File(path)
     options.windowTitle = "SweetUnit"
     options.memberLevel = JavadocMemberLevel.PROTECTED
     options.author = true
-    options.links('http://d.android.com/reference')
+    options.links('https://developer.android.com/reference')
     exclude '**/BuildConfig.java'
     exclude '**/R.java'
     String v = "${SEMVER}"
     version = v.replace("_", '.')
     options.setDocTitle("SweetUnit " + version + " API")
     destinationDir = file("${rootDir.absolutePath}/javadocs/sweetunit/api")
-    source = android.sourceSets.main.java.srcDirs
-    classpath += files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += files(rootProject.projectDir.absolutePath + "/library/build/intermediates/aar_main_jar/release/classes.jar")
-    classpath += configurations.javadocDeps
+    source = android.sourceSets.main.java.sourceFiles
     group = "sweetunit"
 }
 
 // Create javadoc jar file
-task sbjavadocJar(type: Jar, dependsOn: gendocs) {
+tasks.register('sbjavadocJar', Jar) {
+    dependsOn gendocs
     from gendocs.destinationDir
     archiveFileName = getJavadocJarName("sweetunit")
     archiveClassifier.set("javadoc")
@@ -120,4 +140,25 @@ publishing {
             }
         }
     }
+}
+
+
+def static extractClassesJar(File archive, File tmpDir) {
+    byte[] buffer = new byte[1024]
+    ZipInputStream zis = new ZipInputStream(new FileInputStream(archive.absolutePath))
+    ZipEntry zipEntry = zis.getNextEntry()
+    while (zipEntry != null) {
+        if (zipEntry.name.equalsIgnoreCase("classes.jar")) {
+            def classFile = new File(tmpDir, archive.name.replace(".aar", ".jar"))
+            FileOutputStream fos = new FileOutputStream(classFile)
+            int len
+            while ((len = zis.read(buffer)) > 0) {
+                fos.write(buffer, 0, len)
+            }
+            fos.close()
+        }
+        zipEntry = zis.getNextEntry()
+    }
+    zis.closeEntry()
+    zis.close()
 }

--- a/sweetunit/build.gradle
+++ b/sweetunit/build.gradle
@@ -61,6 +61,8 @@ afterEvaluate {
     // So, update the gendocs task classpath with the value here
     tasks.gendocs.classpath += files(project.android.getBootClasspath())
     tasks.gendocs.classpath += project(':library').tasks.sourcesJar.outputs.getFiles()
+    // It also seems that aar dependencies don't get properly added to the classpath, so we have
+    // to pull the classes.jar out of them manually and add them to the classpath
     def tmpDir = new File(project.buildDir, "tmpAar")
     if (tmpDir.exists()) tmpDir.delete()
     tmpDir.mkdirs()

--- a/sweetunit/src/main/java/com/idevicesinc/sweetblue/framework/BaseUiAutomatorTest.java
+++ b/sweetunit/src/main/java/com/idevicesinc/sweetblue/framework/BaseUiAutomatorTest.java
@@ -3,9 +3,7 @@ package com.idevicesinc.sweetblue.framework;
 import android.app.Activity;
 import android.widget.EditText;
 
-import androidx.test.core.app.ActivityScenario;
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.rule.ActivityTestRule;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;


### PR DESCRIPTION
* Cleaned up the snapshot deployment script to only deploy. It should also be impossible to deploy a release version with this action. 
* Updated build.gradle to look for useSnapshot parameter, and adjust the versionName accordingly.
* Fixed some javadoc generation issues which were caused by the upgrading of the gradle, and android gradle plugin versions to the latest